### PR TITLE
🐘 Setup Gradle and warmup build before executing CC experiment

### DIFF
--- a/.github/workflows/gradle-experiments.yaml
+++ b/.github/workflows/gradle-experiments.yaml
@@ -63,6 +63,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-java
+      - uses: ./.github/actions/setup-gradle
+        with:
+          cache-disabled: true
+      - uses: ./.github/actions/setup-gradle-properties
+      - name: Warmup # i.e. store initial Android cache like .config/.android/cache
+        run: ./gradlew ${{ env.TASKS }} --no-configuration-cache --dry-run --no-daemon
       - name: Run configuration cache experiment
         uses: gradle/develocity-build-validation-scripts/.github/actions/gradle/experiment-config-cache@f4b4a15ed96225ae1b6d3a09201a22f166f97fc5 # v2.7.3
         with:


### PR DESCRIPTION
To prevent the initial Android bootstrap to influence the Configuration Cache inputs:
> the file system entry '../../../.config/.android/cache' has been created