### PR TITLE
🕵️ Analyze Lint's merged SARIF report instead of individual files

### DIFF
--- a/.github/actions/archive-lint-reports/action.yaml
+++ b/.github/actions/archive-lint-reports/action.yaml
@@ -2,7 +2,7 @@ name: 📦 Archive Lint reports
 description: Archive Lint reports
 inputs:
   analysis:
-    description: A file or directory to be uploaded to GitHub code scanning
+    description: A SARIF file to run CodeQL analysis on
   html:
     description: A file, directory or wildcard pattern that describes what to upload
   sarif:
@@ -12,26 +12,27 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Archive Lint HTML report
+    - name: Archive Lint HTML reports
       if: inputs.html != ''
       uses: actions/upload-artifact@v4
       with:
         name: lint-html
         path: ${{ inputs.html }}
-    - name: Archive Lint SARIF report
-      if: inputs.sarif != ''
-      uses: actions/upload-artifact@v4
-      with:
-        name: lint-sarif
-        path: ${{ inputs.sarif }}
-    - name: Archive Lint XML report
+    - name: Archive Lint XML reports
       if: inputs.xml != ''
       uses: actions/upload-artifact@v4
       with:
         name: lint-xml
         path: ${{ inputs.xml }}
+    - name: Archive Lint SARIF reports
+      if: inputs.sarif != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: lint-sarif
+        path: ${{ inputs.sarif }}
     - name: Analyse Lint SARIF report
-      if: inputs.analysis != '' && (hashFiles(inputs.analysis) != '' || hashFiles(format('{0}/**/*.sarif', inputs.analysis)) != '')
+      if: inputs.analysis != ''
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: ${{ inputs.analysis }}
+        category: android-lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.label || github.head_ref || github.ref }}
@@ -110,6 +112,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      pull-requests: write
       # github/codeql-action/upload-sarif
       security-events: write
     runs-on: ubuntu-latest
@@ -124,12 +127,13 @@ jobs:
 
       - name: 🕵️ Lint
         id: lint
-        run: ./gradlew globalCiLint
+        run: ./gradlew globalCiLint --continue
       - name: 📦 Archive Lint reports
         if: ${{ always() && contains(fromJSON('["success", "failure"]'), steps.lint.outcome) }}
         uses: ./.github/actions/archive-lint-reports
         with:
-          analysis: './'
-          html: "**/build/reports/lint-results-*.html"
-          sarif: "**/build/reports/lint-results-*.sarif"
-          xml: "**/build/reports/lint-results-*.xml"
+          # hard-coded path to the merged lint report
+          analysis: app/build/reports/lint-results-release.sarif
+          html: "**/build/reports/lint-results*.html"
+          sarif: "**/build/reports/lint-results*.sarif"
+          xml: "**/build/reports/lint-results*.xml"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,6 @@ android {
 dependencies {
     baselineProfile(projects.profiling)
 
-    lintChecks(projects.lint)
-
     implementation(libs.androidx.core)
     implementation(libs.androidx.datastore)
     implementation(libs.androidx.navigation)
@@ -39,6 +37,16 @@ dependencies {
     implementation(projects.domain.settings)
     implementation(projects.data.dice)
     implementation(projects.data.settings)
+
+    compileOnly(projects.lint) {
+        isTransitive = false
+        because(
+            """
+            Android Lint does not seem to behave as expected when executed on isolated JVM modules. 🤦
+            The workaround is to add them to an Android module's dependency graph and enable `checkDependencies`.
+            """.trimIndent()
+        )
+    }
 }
 
 idea {

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundLint.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundLint.kt
@@ -90,6 +90,7 @@ internal object PlaygroundLint {
         sarifReport = true
 
         checkDependencies = true
+        absolutePaths = true
 
         disable += "AndroidGradlePluginVersion"
         disable += "GradleDependency"


### PR DESCRIPTION
To fix GitHub's stupid deprecation policy:

> Uploading multiple SARIF runs with the same category is deprecated and will be removed on June 4, 2025. Please update your workflow to upload a single run per category. For more information, see https://github.blog/changelog/2024-05-06-code-scanning-will-stop-combining-runs-from-a-single-upload