### PR TITLE
📦 Simplify PlaygroundBadging code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: ./.github/actions/check-gradle-dependency-lock-state
       - run: ./gradlew apiCheck --quiet
-      - run: ./gradlew globalCiBadging -Pplayground.isMinifyEnabled=false --quiet
+      - run: ./gradlew ciBadging -Pplayground.isMinifyEnabled=false --quiet
 
   build:
     name: 👷 Build

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | `gradlew apiCheck`                                               | Checks project public API ([BCV](https://github.com/Kotlin/binary-compatibility-validator)) |
 | `gradlew apiDump`                                                | Dumps project public API ([BCV](https://github.com/Kotlin/binary-compatibility-validator))  |
 | `gradlew dependencyLockState --write-locks`                      | Updates dependency lock state                                                               |
-| `gradlew globalCiBadging`                                        | CI badging checks                                                                           |
+| `gradlew ciBadging -Pplayground.isMinifyEnabled=false`           | CI badging checks                                                                           |
 | `gradlew globalCiLint`                                           | CI Lint checks (html/sarif/txt/xml)                                                         |
 | `gradlew globalCiUnitTest`                                       | CI unit tests (html/xml)                                                                    |
 | `gradlew generateBaselineProfile`                                | Generates Baseline & Startup profiles                                                       |


### PR DESCRIPTION
- Reorder Tasks parameters: inputs > outputs > others
- Remove unnecessary `project`, already available as a receiver
- Replace `:globalCiBadging` with `:ciBadging` to avoid crossing project isolation boundary