### PR TITLE
Replace Kotlinx Serialization dependency on build-logic with simple escaping

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -37,8 +37,6 @@ dependencies {
     implementation(plugin(libs.plugins.artifactsSizeReport))
     implementation(libs.android.tools.common)
     implementation(libs.assertk)
-    implementation(platform(libs.kotlinx.serialization.bom))
-    implementation(libs.kotlinx.serialization.json)
     lintChecks(libs.androidx.lint.gradle)
 }
 


### PR DESCRIPTION
This should allow us to update Kotlinx Serialization to v1.9 that currently requires a higher Kotlin metadata version than the Gradle embeded Kotlin has.