### PR TITLE
🔏 Regenerate metadata entries based on globalCi task

### DIFF
--- a/.github/workflows/dependabot-gradle-dependencies.yaml
+++ b/.github/workflows/dependabot-gradle-dependencies.yaml
@@ -36,7 +36,10 @@ jobs:
 
       - id: gradle-signature-verification
         run: |
-          ./gradlew --write-verification-metadata pgp,sha256 --export-keys
+          ./gradlew globalCi --write-verification-metadata pgp,sha256 --export-keys --dry-run
+
+          mv gradle/verification-metadata.dryrun.xml gradle/verification-metadata.xml
+          mv gradle/verification-keyring.dryrun.keys gradle/verification-keyring.keys
 
           # Remove unnecessary version attributes from trusted-key entries
           sed -i 's/<trusted-key\(.*\) version="[^"]*"/<trusted-key\1/g' gradle/verification-metadata.xml

--- a/.github/workflows/gradle-dependency-signatures.yaml
+++ b/.github/workflows/gradle-dependency-signatures.yaml
@@ -9,7 +9,7 @@ on:
         required: false
         type: string
       no-dry-run:
-        description: Don't use --dry-run, to execute the corresponding tasks
+        description: Don't use --dry-run, to execute the tasks
         required: false
         type: boolean
 

--- a/.github/workflows/gradle-dependency-signatures.yaml
+++ b/.github/workflows/gradle-dependency-signatures.yaml
@@ -8,6 +8,10 @@ on:
         description: PR number, branch, or url
         required: false
         type: string
+      no-dry-run:
+        description: Don't use --dry-run, to execute the corresponding tasks
+        required: false
+        type: boolean
 
 permissions:
   contents: write
@@ -39,7 +43,25 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
       - uses: ./.github/actions/setup-gradle-properties
 
-      - run: ./gradlew --write-verification-metadata pgp,sha256 --export-keys
+      - name: Verification without --dry-run
+        if: inputs.no-dry-run == 'true'
+        run: |
+          sudo apt-get install -y xmlstarlet
+          xmlstarlet edit --inplace \
+            -N g="https://schema.gradle.org/dependency-verification" \
+            --delete 'g:verification-metadata/g:configuration/g:ignored-keys' \
+            --delete 'g:verification-metadata/g:components/*' \
+            gradle/verification-metadata.xml
+          rm gradle/verification-keyring.keys
+          ./gradlew globalCi --write-verification-metadata pgp,sha256 --export-keys
+
+      - name: Verification with --dry-run
+        if: inputs.no-dry-run != 'true'
+        run: |
+          ./gradlew globalCi --write-verification-metadata pgp,sha256 --export-keys --dry-run
+          mv gradle/verification-metadata.dryrun.xml gradle/verification-metadata.xml
+          mv gradle/verification-keyring.dryrun.keys gradle/verification-keyring.keys
+
       - run: |
           # Remove unnecessary version attributes from trusted-key entries
           sed -i 's/<trusted-key\(.*\) version="[^"]*"/<trusted-key\1/g' gradle/verification-metadata.xml

--- a/README.md
+++ b/README.md
@@ -9,28 +9,28 @@
 
 #### 🐘 Gradle
 
-| Task                                                             | Description                                                                                 |
-|------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| `gradlew assembleDebug`                                          | Build debug APK                                                                             |
-| `gradlew assembleRelease`                                        | Build release APK (optimized & minified)                                                    |
-| `gradlew apiCheck`                                               | Checks project public API ([BCV](https://github.com/Kotlin/binary-compatibility-validator)) |
-| `gradlew apiDump`                                                | Dumps project public API ([BCV](https://github.com/Kotlin/binary-compatibility-validator))  |
-| `gradlew licensee`                                               | Runs [Licensee](https://github.com/cashapp/licensee) dependency license validation          |
-| `gradlew topologyCheck`                                          | Checks the topology of project dependencies                                                 |
-| `gradlew dependencyLockState --write-locks`                      | Updates dependency lock state                                                               |
-| `gradlew ciBadging -Pplayground.isMinifyEnabled=false`           | CI badging checks                                                                           |
-| `gradlew globalCiLint`                                           | CI Lint checks (html/sarif/txt/xml)                                                         |
-| `gradlew globalCiUnitTest`                                       | CI unit tests (html/xml)                                                                    |
-| `gradlew verifyScreenshots`                                      | Verify screenshot tests images against golden images                                        |
-| `gradlew recordScreenshots`                                      | Record screenshot tests golden images                                                       |
-| `gradlew cleanRecordScreenshots`                                 | Clean and record screenshot tests golden images                                             |
-| `gradlew generateBaselineProfile`                                | Generates Baseline & Startup profiles                                                       |
-| `gradlew connectedBenchmarkAndroidTest`                          | Runs benchmark tests                                                                        |
-| `gradlew assembleRelease -Pplayground.compose.compilerMetrics`   | Compose compiler metrics                                                                    |
-| `gradlew assembleRelease -Pplayground.compose.compilerReports`   | Compose compiler reports                                                                    |
-| `gradlew --write-verification-metadata pgp,sha256 --export-keys` | Generates verification metadata & keyring                                                   |
-| `gradlew graphDump`                                              | Dumps project dependencies to a mermaid file                                                |
-| `gradlew graphUpdate`                                            | Updates Markdown file with the corresponding dependency graph                               |
+| Task                                                                      | Description                                                                                |
+|---------------------------------------------------------------------------|--------------------------------------------------------------------------------------------|
+| `gradlew assembleDebug`                                                   | Build debug APK                                                                            |
+| `gradlew assembleRelease`                                                 | Build release APK (optimized & minified)                                                   |
+| `gradlew apiCheck`                                                        | Checks project public API ([BCV](https://github.com/Kotlin/binary-compatibility-validator)) |
+| `gradlew apiDump`                                                         | Dumps project public API ([BCV](https://github.com/Kotlin/binary-compatibility-validator)) |
+| `gradlew licensee`                                                        | Runs [Licensee](https://github.com/cashapp/licensee) dependency license validation         |
+| `gradlew topologyCheck`                                                   | Checks the topology of project dependencies                                                |
+| `gradlew dependencyLockState --write-locks`                               | Updates dependency lock state                                                              |
+| `gradlew ciBadging -Pplayground.isMinifyEnabled=false`                    | CI badging checks                                                                          |
+| `gradlew globalCiLint`                                                    | CI Lint checks (html/sarif/txt/xml)                                                        |
+| `gradlew globalCiUnitTest`                                                | CI unit tests (html/xml)                                                                   |
+| `gradlew verifyScreenshots`                                               | Verify screenshot tests images against golden images                                       |
+| `gradlew recordScreenshots`                                               | Record screenshot tests golden images                                                      |
+| `gradlew cleanRecordScreenshots`                                          | Clean and record screenshot tests golden images                                            |
+| `gradlew generateBaselineProfile`                                         | Generates Baseline & Startup profiles                                                      |
+| `gradlew connectedBenchmarkAndroidTest`                                   | Runs benchmark tests                                                                       |
+| `gradlew assembleRelease -Pplayground.compose.compilerMetrics`            | Compose compiler metrics                                                                   |
+| `gradlew assembleRelease -Pplayground.compose.compilerReports`            | Compose compiler reports                                                                   |
+| `gradlew globalCi --write-verification-metadata pgp,sha256 --export-keys` | Generates verification metadata & keyring                                                  |
+| `gradlew graphDump`                                                       | Dumps project dependencies to a mermaid file                                               |
+| `gradlew graphUpdate`                                                     | Updates Markdown file with the corresponding dependency graph                              |
 
 #### 🐙 GitHub workflows
 

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/PlaygroundAndroidApplicationPlugin.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/PlaygroundAndroidApplicationPlugin.kt
@@ -6,6 +6,7 @@ import app.cash.licensee.SpdxId
 import fr.smarquis.playground.buildlogic.dsl.apply
 import fr.smarquis.playground.buildlogic.dsl.assign
 import fr.smarquis.playground.buildlogic.dsl.configure
+import fr.smarquis.playground.buildlogic.utils.PlaygroundGlobalCi
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -51,5 +52,7 @@ internal class PlaygroundAndroidApplicationPlugin : Plugin<Project> {
             allow(SpdxId.BSD_3_Clause)
             allow(SpdxId.MIT)
         }
+        PlaygroundGlobalCi.addToGlobalCi(project, "assembleRelease")
+        PlaygroundGlobalCi.addToGlobalCi(project, "licensee")
     }
 }

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/PlaygroundAndroidLibraryPlugin.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/PlaygroundAndroidLibraryPlugin.kt
@@ -1,6 +1,7 @@
 package fr.smarquis.playground.buildlogic
 
 import fr.smarquis.playground.buildlogic.dsl.apply
+import fr.smarquis.playground.buildlogic.utils.PlaygroundGlobalCi
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -16,6 +17,7 @@ internal class PlaygroundAndroidLibraryPlugin : Plugin<Project> {
                 aarMetadata.minCompileSdk = versions.minSdk.toString().toInt()
             }
         }
+        PlaygroundGlobalCi.addToGlobalCi(project, "apiCheck")
     }
 
 }

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/PlaygroundBasePlugin.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/PlaygroundBasePlugin.kt
@@ -3,6 +3,7 @@ package fr.smarquis.playground.buildlogic
 import fr.smarquis.playground.buildlogic.dsl.apply
 import fr.smarquis.playground.buildlogic.dsl.withType
 import fr.smarquis.playground.buildlogic.utils.PlaygroundBadging
+import fr.smarquis.playground.buildlogic.utils.PlaygroundGlobalCi
 import fr.smarquis.playground.buildlogic.utils.PlaygroundDependencyLocking
 import fr.smarquis.playground.buildlogic.utils.PlaygroundGraph
 import fr.smarquis.playground.buildlogic.utils.PlaygroundLint
@@ -22,6 +23,7 @@ internal class PlaygroundBasePlugin : Plugin<Project> {
             apply(plugin = "org.gradle.android.cache-fix")
         }
 
+        PlaygroundGlobalCi.configureSubproject(target)
         PlaygroundUnitTests.configureSubproject(target)
         PlaygroundLint.configureSubproject(target)
         PlaygroundBadging.configureProject(target)

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/PlaygroundRootPlugin.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/PlaygroundRootPlugin.kt
@@ -1,6 +1,7 @@
 package fr.smarquis.playground.buildlogic
 
 import fr.smarquis.playground.buildlogic.utils.PlaygroundBadging
+import fr.smarquis.playground.buildlogic.utils.PlaygroundGlobalCi
 import fr.smarquis.playground.buildlogic.utils.PlaygroundLint
 import fr.smarquis.playground.buildlogic.utils.PlaygroundUnitTests
 import org.gradle.api.Plugin
@@ -13,6 +14,7 @@ internal class PlaygroundRootPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         require(target == target.rootProject) { "$this must be applied on the root project, but was applied on $target" }
+        PlaygroundGlobalCi.configureRootProject(target)
         PlaygroundUnitTests.configureRootProject(target)
         PlaygroundLint.configureRootProject(target)
         PlaygroundBadging.configureRootProject(target)

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/PlaygroundScreenshotsPlugin.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/PlaygroundScreenshotsPlugin.kt
@@ -2,6 +2,7 @@ package fr.smarquis.playground.buildlogic
 
 import app.cash.paparazzi.gradle.PaparazziPlugin
 import fr.smarquis.playground.buildlogic.dsl.apply
+import fr.smarquis.playground.buildlogic.utils.PlaygroundGlobalCi
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.language.base.plugins.LifecycleBasePlugin.VERIFICATION_GROUP
@@ -24,7 +25,7 @@ internal class PlaygroundScreenshotsPlugin : Plugin<Project> {
                 group = VERIFICATION_GROUP
                 description = "Verify screenshot tests images against golden images."
                 dependsOn("verifyPaparazzi${screenshotTestingVariant.get()}")
-            }
+            }.also { PlaygroundGlobalCi.addToGlobalCi(project, it) }
         }
     }
 

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/PlaygroundScreenshotsPlugin.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/PlaygroundScreenshotsPlugin.kt
@@ -25,7 +25,9 @@ internal class PlaygroundScreenshotsPlugin : Plugin<Project> {
                 group = VERIFICATION_GROUP
                 description = "Verify screenshot tests images against golden images."
                 dependsOn("verifyPaparazzi${screenshotTestingVariant.get()}")
-            }.also { PlaygroundGlobalCi.addToGlobalCi(project, it) }
+            }.also {
+                PlaygroundGlobalCi.addToGlobalCi(project, it)
+            }
         }
     }
 

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundBadging.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundBadging.kt
@@ -52,7 +52,9 @@ internal object PlaygroundBadging {
         project.tasks.register(CI_BADGING_TASK_NAME) {
             group = VERIFICATION_GROUP
             description = "Global lifecycle task to run all $CI_BADGING_TASK_NAME tasks."
-        }.also { PlaygroundGlobalCi.addToGlobalCi(project, it) }
+        }.also {
+            PlaygroundGlobalCi.addToGlobalCi(project, it)
+        }
 
     fun configureProject(project: Project) = with(project) {
         pluginManager.withPlugin("com.android.application") {

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundBadging.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundBadging.kt
@@ -52,7 +52,7 @@ internal object PlaygroundBadging {
         project.tasks.register(CI_BADGING_TASK_NAME) {
             group = VERIFICATION_GROUP
             description = "Global lifecycle task to run all $CI_BADGING_TASK_NAME tasks."
-        }
+        }.also { PlaygroundGlobalCi.addToGlobalCi(project, it) }
 
     fun configureProject(project: Project) = with(project) {
         pluginManager.withPlugin("com.android.application") {

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundGlobalCi.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundGlobalCi.kt
@@ -1,0 +1,21 @@
+package fr.smarquis.playground.buildlogic.utils
+
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.TaskProvider
+
+/**
+ * Inspired by [androidx/androidx](https://github.com/androidx/androidx/blob/androidx-main/buildSrc/public/src/main/kotlin/androidx/build/BuildOnServer.kt)
+ */
+public object PlaygroundGlobalCi {
+    internal const val GLOBAL_CI_TASK = "globalCi"
+
+    public fun configureRootProject(project: Project): TaskProvider<Task> = project.tasks.register(GLOBAL_CI_TASK)
+    public fun configureSubproject(project: Project): TaskProvider<Task> = project.tasks.register(GLOBAL_CI_TASK)
+
+    public fun <T : Task> addToGlobalCi(project: Project, taskProvider: TaskProvider<T>): Unit =
+        project.tasks.named(GLOBAL_CI_TASK).configure { dependsOn(taskProvider) }
+
+    public fun addToGlobalCi(project: Project, taskPath: String): Unit =
+        project.tasks.named(GLOBAL_CI_TASK).configure { dependsOn(taskPath) }
+}

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundLint.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundLint.kt
@@ -26,7 +26,9 @@ internal object PlaygroundLint {
         project.tasks.register(GLOBAL_CI_LINT_TASK_NAME) {
             group = LifecycleBasePlugin.VERIFICATION_GROUP
             description = "Global lifecycle task to run all ciLint tasks."
-        }.also { PlaygroundGlobalCi.addToGlobalCi(project, it) }
+        }.also {
+            PlaygroundGlobalCi.addToGlobalCi(project, it)
+        }
 
     fun configureSubproject(project: Project) = with(project) {
         val globalTask = rootProject.tasks.named(GLOBAL_CI_LINT_TASK_NAME)

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundLint.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundLint.kt
@@ -26,7 +26,7 @@ internal object PlaygroundLint {
         project.tasks.register(GLOBAL_CI_LINT_TASK_NAME) {
             group = LifecycleBasePlugin.VERIFICATION_GROUP
             description = "Global lifecycle task to run all ciLint tasks."
-        }
+        }.also { PlaygroundGlobalCi.addToGlobalCi(project, it) }
 
     fun configureSubproject(project: Project) = with(project) {
         val globalTask = rootProject.tasks.named(GLOBAL_CI_LINT_TASK_NAME)

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundTopology.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundTopology.kt
@@ -51,7 +51,9 @@ internal object PlaygroundTopology {
             projectPath = isolated.path
             dependencies = configurations.flatMap { it.dependencies.withType<ProjectDependency>().map { it.path } }.toSet()
             output = layout.buildDirectory.file("intermediates/$name/topology.txt")
-        }.also { PlaygroundGlobalCi.addToGlobalCi(project, it) }
+        }.also {
+            PlaygroundGlobalCi.addToGlobalCi(project, it)
+        }
     }
 
 }

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundTopology.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundTopology.kt
@@ -51,7 +51,7 @@ internal object PlaygroundTopology {
             projectPath = isolated.path
             dependencies = configurations.flatMap { it.dependencies.withType<ProjectDependency>().map { it.path } }.toSet()
             output = layout.buildDirectory.file("intermediates/$name/topology.txt")
-        }
+        }.also { PlaygroundGlobalCi.addToGlobalCi(project, it) }
     }
 
 }

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundUnitTests.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundUnitTests.kt
@@ -38,7 +38,9 @@ internal object PlaygroundUnitTests {
         project.tasks.register(GLOBAL_CI_UNIT_TEST_TASK_NAME) {
             group = LifecycleBasePlugin.VERIFICATION_GROUP
             description = "Global lifecycle task to run all ciUnitTest tasks."
-        }.also { PlaygroundGlobalCi.addToGlobalCi(project, it) }
+        }.also {
+            PlaygroundGlobalCi.addToGlobalCi(project, it)
+        }
 
     fun configureSubproject(project: Project) = with(project) {
         if (isAndroidTest) return@with // Android Test modules are special, they don't have tests...

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundUnitTests.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundUnitTests.kt
@@ -38,7 +38,7 @@ internal object PlaygroundUnitTests {
         project.tasks.register(GLOBAL_CI_UNIT_TEST_TASK_NAME) {
             group = LifecycleBasePlugin.VERIFICATION_GROUP
             description = "Global lifecycle task to run all ciUnitTest tasks."
-        }
+        }.also { PlaygroundGlobalCi.addToGlobalCi(project, it) }
 
     fun configureSubproject(project: Project) = with(project) {
         if (isAndroidTest) return@with // Android Test modules are special, they don't have tests...


### PR DESCRIPTION
and allow no `--dry-run` option to edit in-place.