### PR TITLE
⚙️ Truncate `verification-keyring.keys` instead of deleting

### DIFF
--- a/.github/workflows/gradle-dependency-signatures.yaml
+++ b/.github/workflows/gradle-dependency-signatures.yaml
@@ -52,7 +52,7 @@ jobs:
             --delete 'g:verification-metadata/g:configuration/g:ignored-keys' \
             --delete 'g:verification-metadata/g:components/*' \
             gradle/verification-metadata.xml
-          rm gradle/verification-keyring.keys
+          > gradle/verification-keyring.keys
           ./gradlew globalCi --write-verification-metadata pgp,sha256 --export-keys
 
       - name: Verification with --dry-run


### PR DESCRIPTION
To prevent git from forgetting about this file...