### PR TITLE
🔐 Turn off `verify-metadata` (`.pom` and `.module`)

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <verification-metadata xmlns="https://schema.gradle.org/dependency-verification" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://schema.gradle.org/dependency-verification https://schema.gradle.org/dependency-verification/dependency-verification-1.3.xsd">
    <configuration>
-      <verify-metadata>true</verify-metadata>
+      <verify-metadata>false</verify-metadata>
       <verify-signatures>true</verify-signatures>
       <keyring-format>armored</keyring-format>
       <key-servers enabled="false">


### PR DESCRIPTION
This seems to be too many incompatibilities with caching, leading to missing entries and hard to debug/update.