### PR TITLE
🕵️ Fix lint SARIF reports analysis

### DIFF
--- a/.github/actions/archive-lint-reports/action.yaml
+++ b/.github/actions/archive-lint-reports/action.yaml
@@ -1,8 +1,6 @@
 name: 📦 Archive Lint reports
 description: Archive Lint reports
 inputs:
-  analysis:
-    description: A SARIF file to run CodeQL analysis on
   html:
     description: A file, directory or wildcard pattern that describes what to upload
   sarif:
@@ -33,9 +31,3 @@ runs:
         name: lint-sarif
         path: ${{ inputs.sarif }}
         if-no-files-found: ignore
-    - name: Analyse Lint SARIF report
-      if: inputs.analysis != ''
-      uses: github/codeql-action/upload-sarif@v3
-      with:
-        sarif_file: ${{ inputs.analysis }}
-        category: android-lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,15 +151,25 @@ jobs:
 
       - name: 🕵️ Lint
         id: lint
-        run: ./gradlew globalCiLint --continue
+        run: ./gradlew globalCiLint :build-logic:lint --continue
       - name: 📦 Archive Lint reports
         if: ${{ !cancelled() && contains(fromJSON('["success", "failure"]'), steps.lint.outcome) }}
         uses: ./.github/actions/archive-lint-reports
         with:
-          # hard-coded path to the merged lint report
-          analysis: app/build/reports/lint-results-release.sarif
           html: "**/build/reports/lint-results*.html"
           sarif: "**/build/reports/lint-results*.sarif"
           xml: "**/build/reports/lint-results*.xml"
+      - name: 🔍 Analyze app SARIF report
+        if: ${{ !cancelled() && hashFiles('app/build/reports/lint-results-release.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: app/build/reports/lint-results-release.sarif
+          category: app
+      - name: 🔍 Analyze build-logic SARIF report
+        if: ${{ !cancelled() && hashFiles('build-logic/build/reports/lint-results.sarif') != '' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: build-logic/build/reports/lint-results.sarif
+          category: build-logic
       - if: ${{ !cancelled() }}
         uses: ./.github/actions/archive-gradle-reports

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -93,6 +93,10 @@ private fun NamedDomainObjectContainer<PluginDeclaration>.create(
     implementationClass = "fr.smarquis.playground.buildlogic.$name"
 }
 
+lint {
+    abortOnError = true
+}
+
 // Check Kotlin/KSP versions mismatch
 val kotlin = libs.versions.kotlin.get()
 val ksp = libs.plugins.ksp.get().version.toString()

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/PlaygroundRootPlugin.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/PlaygroundRootPlugin.kt
@@ -13,7 +13,7 @@ import org.gradle.api.Project
 internal class PlaygroundRootPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
-        require(target == target.rootProject) { "$this must be applied on the root project, but was applied on $target" }
+        require(target.isolated == target.isolated.rootProject) { "$this must be applied on the root project, but was applied on $target" }
         PlaygroundGlobalCi.configureRootProject(target)
         PlaygroundUnitTests.configureRootProject(target)
         PlaygroundLint.configureRootProject(target)

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundBadging.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundBadging.kt
@@ -79,13 +79,13 @@ internal object PlaygroundBadging {
         val updateBadgingTaskName = "update${capitalizedVariantName}Badging"
         tasks.register<Copy>(updateBadgingTaskName) {
             description = "Copies the generated badging file into the main project directory."
-            from(generateBadging.get().badging)
+            from(generateBadging.map { it.badging })
             into(layout.projectDirectory)
         }
 
         val checkBadgingTask = tasks.register<CheckBadgingTask>("check${capitalizedVariantName}Badging") {
             goldenBadging = layout.projectDirectory.file("${variant.name}-badging.txt")
-            generatedBadging = generateBadging.get().badging
+            generatedBadging = generateBadging.flatMap { it.badging }
             updateTask = updateBadgingTaskName
             output = layout.buildDirectory.dir("intermediates/$name")
         }

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundGraph.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundGraph.kt
@@ -60,8 +60,8 @@ internal object PlaygroundGraph {
         }
         project.tasks.register<GraphUpdateTask>("graphUpdate") {
             projectPath = project.path
-            input = dumpTask.get().output
-            output = project.run { (if (path == MAIN_PROJECT_PATH) rootProject else this).layout.projectDirectory.file("README.md") }
+            input = dumpTask.flatMap { it.output }
+            output = project.run { (if (path == MAIN_PROJECT_PATH) isolated.rootProject else isolated).projectDirectory.file("README.md") }
         }
     }
 


### PR DESCRIPTION
and add missing `:build-logic:lint`

Source: https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/