### PR TITLE
⚙️ Remove `globalCiLint` & `globalCiUnitTest` to prevent breaking project isolation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,7 +117,7 @@ jobs:
 
       - name: 🧑‍🔬 Test
         id: test
-        run: ./gradlew globalCiUnitTest verifyScreenshots
+        run: ./gradlew ciUnitTest verifyScreenshots
       - name: 📦 Archive JUnit reports
         if: ${{ !cancelled() && contains(fromJSON('["success", "failure"]'), steps.test.outcome) }}
         uses: ./.github/actions/archive-junit-reports
@@ -151,7 +151,7 @@ jobs:
 
       - name: 🕵️ Lint
         id: lint
-        run: ./gradlew globalCiLint :build-logic:lint --continue
+        run: ./gradlew ciLint :build-logic:lint --continue
       - name: 📦 Archive Lint reports
         if: ${{ !cancelled() && contains(fromJSON('["success", "failure"]'), steps.lint.outcome) }}
         uses: ./.github/actions/archive-lint-reports

--- a/.github/workflows/gradle-experiments.yaml
+++ b/.github/workflows/gradle-experiments.yaml
@@ -10,7 +10,7 @@ permissions:
 
 env:
   DEVELOCITY_URL: https://scans.gradle.com
-  TASKS: apiCheck licensee assembleRelease globalCiUnitTest globalCiLint verifyScreenshots
+  TASKS: apiCheck licensee assembleRelease ciUnitTest ciLint verifyScreenshots
 
 jobs:
   build-cache-compatibility:

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 | `gradlew topologyCheck`                                                   | Checks the topology of project dependencies                                                |
 | `gradlew dependencyLockState --write-locks`                               | Updates dependency lock state                                                              |
 | `gradlew ciBadging -Pplayground.isMinifyEnabled=false`                    | CI badging checks                                                                          |
-| `gradlew globalCiLint`                                                    | CI Lint checks (html/sarif/txt/xml)                                                        |
-| `gradlew globalCiUnitTest`                                                | CI unit tests (html/xml)                                                                   |
+| `gradlew ciLint`                                                          | CI Lint checks (html/sarif/txt/xml)                                                        |
+| `gradlew ciUnitTest`                                                      | CI unit tests (html/xml)                                                                   |
 | `gradlew verifyScreenshots`                                               | Verify screenshot tests images against golden images                                       |
 | `gradlew recordScreenshots`                                               | Record screenshot tests golden images                                                      |
 | `gradlew cleanRecordScreenshots`                                          | Clean and record screenshot tests golden images                                            |

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/PlaygroundRootPlugin.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/PlaygroundRootPlugin.kt
@@ -2,8 +2,6 @@ package fr.smarquis.playground.buildlogic
 
 import fr.smarquis.playground.buildlogic.utils.PlaygroundBadging
 import fr.smarquis.playground.buildlogic.utils.PlaygroundGlobalCi
-import fr.smarquis.playground.buildlogic.utils.PlaygroundLint
-import fr.smarquis.playground.buildlogic.utils.PlaygroundUnitTests
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -15,8 +13,6 @@ internal class PlaygroundRootPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         require(target.isolated == target.isolated.rootProject) { "$this must be applied on the root project, but was applied on $target" }
         PlaygroundGlobalCi.configureRootProject(target)
-        PlaygroundUnitTests.configureRootProject(target)
-        PlaygroundLint.configureRootProject(target)
         PlaygroundBadging.configureRootProject(target)
     }
 


### PR DESCRIPTION
and use project-level `ciLint` & `ciUnitTest` tasks directly.