### PR TITLE
Migrate to `com.android.tools.build:gradle-api`

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -32,12 +32,7 @@ assignment {
 }
 
 dependencies {
-    compileOnly(plugin(libs.plugins.android.application))
     compileOnly(plugin(libs.plugins.android.cacheFix))
-    compileOnly(plugin(libs.plugins.android.library))
-    compileOnly(plugin(libs.plugins.android.lint))
-    compileOnly(plugin(libs.plugins.android.settings))
-    compileOnly(plugin(libs.plugins.android.test))
     compileOnly(plugin(libs.plugins.androidx.baselineprofile))
     compileOnly(plugin(libs.plugins.androidx.navigation))
     compileOnly(plugin(libs.plugins.artifactsSizeReport))
@@ -52,6 +47,7 @@ dependencies {
     compileOnly(plugin(libs.plugins.licensee))
     compileOnly(plugin(libs.plugins.paparazzi))
 
+    implementation(libs.android.gradle.api)
     implementation(libs.android.tools.common)
     implementation(libs.assertk)
     lintChecks(libs.androidx.lint.gradle)

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/PlaygroundAndroidBasePlugin.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/PlaygroundAndroidBasePlugin.kt
@@ -15,17 +15,18 @@ internal class PlaygroundAndroidBasePlugin : Plugin<Project> {
         apply<AndroidArtifactsInfoPlugin>()
         configureKotlin<KotlinAndroidProjectExtension>()
 
-        androidBase {
+        android {
             namespace = "fr.smarquis.playground." +
                 path.split("""\W""".toRegex()).drop(1).distinct().joinToString(separator = ".").lowercase()
             resourcePrefix = "playground_" +
                 path.split("""\W""".toRegex()).drop(1).distinct().joinToString(separator = "_").lowercase() + "_"
 
-            compileSdkVersion(versions.compileSdk.toString().toInt())
+            compileSdk {
+                version = release(versions.compileSdk.toString().toInt())
+            }
 
             defaultConfig {
                 minSdk = versions.minSdk.toString().toInt()
-                targetSdk = versions.targetSdk.toString().toInt()
                 testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
             }
 
@@ -33,7 +34,7 @@ internal class PlaygroundAndroidBasePlugin : Plugin<Project> {
                 animationsDisabled = true
             }
 
-            packagingOptions {
+            packaging {
                 resources {
                     excludes += "/META-INF/{AL2.0,LGPL2.1}"
                 }

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/Project.ext.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/Project.ext.kt
@@ -17,7 +17,6 @@ import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.android.build.api.variant.TestAndroidComponentsExtension
 import com.android.build.api.variant.Variant
 import com.android.build.api.variant.VariantBuilder
-import com.android.build.gradle.BaseExtension
 import fr.smarquis.playground.buildlogic.dsl.assign
 import fr.smarquis.playground.buildlogic.dsl.configure
 import fr.smarquis.playground.buildlogic.dsl.findByType
@@ -55,7 +54,6 @@ internal fun Project.android(
 internal fun Project.androidApplication(configure: ApplicationExtension.() -> Unit) = configure<ApplicationExtension>(configure)
 internal fun Project.androidLibrary(configure: LibraryExtension.() -> Unit) = configure<LibraryExtension>(configure)
 internal fun Project.androidTest(configure: TestExtension.() -> Unit) = configure<TestExtension>(configure)
-internal fun Project.androidBase(configure: BaseExtension.() -> Unit) = configure<BaseExtension>(configure)
 internal fun Project.androidComponents(configure: ApplicationAndroidComponentsExtension.() -> Unit) = configure<ApplicationAndroidComponentsExtension>(configure)
 
 internal val Project.androidExtension: AndroidComponentsExtension<out CommonExtension<*, *, *, *, *, *>, out VariantBuilder, out Variant>

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundBadging.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundBadging.kt
@@ -5,8 +5,8 @@ import assertk.assertions.containsExactly
 import com.android.SdkConstants.FD_BUILD_TOOLS
 import com.android.SdkConstants.FN_AAPT2
 import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
-import com.android.build.gradle.BaseExtension
 import fr.smarquis.playground.buildlogic.PlaygroundProperties
 import fr.smarquis.playground.buildlogic.capitalized
 import fr.smarquis.playground.buildlogic.dsl.assign
@@ -63,7 +63,7 @@ internal object PlaygroundBadging {
     }
 
     private fun Project.createAndroidBadgingTasks(
-        baseExtension: BaseExtension = extensions.getByType(),
+        appExtension: ApplicationExtension = extensions.getByType(),
         android: ApplicationAndroidComponentsExtension = extensions.getByType(),
         properties: PlaygroundProperties = playground(),
     ) = android.onVariants { variant ->
@@ -72,7 +72,7 @@ internal object PlaygroundBadging {
         val generateBadging = tasks.register<GenerateBadgingTask>("generate${capitalizedVariantName}Badging") {
             apk = variant.artifacts.get(SingleArtifact.APK_FROM_BUNDLE)
             // TODO: Replace with `sdkComponents.aapt2` when it's available in AGP https://issuetracker.google.com/issues/376815836
-            aapt2 = android.sdkComponents.sdkDirectory.map { it.file("$FD_BUILD_TOOLS/${baseExtension.buildToolsVersion}/$FN_AAPT2") }
+            aapt2 = android.sdkComponents.sdkDirectory.map { it.file("$FD_BUILD_TOOLS/${appExtension.buildToolsVersion}/$FN_AAPT2") }
             badging = layout.buildDirectory.file("outputs/apk_from_bundle/${variant.name}/${variant.name}-badging.txt")
         }
 

--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundLint.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundLint.kt
@@ -9,6 +9,7 @@ import fr.smarquis.playground.buildlogic.dsl.getByType
 import fr.smarquis.playground.buildlogic.isAndroidTest
 import fr.smarquis.playground.buildlogic.libs
 import fr.smarquis.playground.buildlogic.playground
+import fr.smarquis.playground.buildlogic.versions
 import org.gradle.api.Project
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 
@@ -70,6 +71,8 @@ internal object PlaygroundLint {
         lint: Lint,
         properties: PlaygroundProperties = playground(),
     ) = lint.apply {
+        targetSdk = versions.targetSdk.toString().toInt()
+
         abortOnError = true
         warningsAsErrors = properties.lintWarningsAsErrors
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ paparazzi = "2.0.0-SNAPSHOT"
 
 [libraries]
 android-desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.1.5"
+android-gradle-api = { module = "com.android.tools.build:gradle-api", version.ref = "agp" }
 android-security-lint = "com.android.security.lint:lint:1.0.3"
 android-tools-common = { module = "com.android.tools:common", version.ref = "android-tools" }
 


### PR DESCRIPTION
> The gradle-api artifact is the only artifact you need to access DSL and variant API interfaces and classes, and should be used when developing plugins.
> https://developer.android.com/build/releases/gradle-plugin-roadmap#agp-10