### PR TITLE
♻️ Remove Kotlin/KSP version mismatch validation

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -99,19 +99,6 @@ lint {
     absolutePaths = true
 }
 
-// Check Kotlin/KSP versions mismatch
-val kotlin = libs.versions.kotlin.get()
-val ksp = libs.plugins.ksp.get().version.toString()
-if (kotlin != ksp.split("-").first()) {
-    throw GradleException(
-        """
-        Kotlin/KSP versions mismatch:
-        - Kotlin: $kotlin
-        - KSP:    $ksp
-        """.trimIndent(),
-    )
-}
-
 // Check AGP & Android Tools versions mismatch
 // https://googlesamples.github.io/android-custom-lint-rules/api-guide.html#example:samplelintcheckgithubproject/lintversion?
 val agp = libs.versions.agp.get()


### PR DESCRIPTION
> KSP is now independent of Kotlin Versions

https://github.com/google/ksp/releases/tag/2.3.0