### PR TITLE
Remove kotlin-ksp patterns from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,11 +26,6 @@ updates:
           - com.android.lint
           - com.android.settings
           - com.android.test
-      kotlin-ksp:
-        patterns:
-          - org.jetbrains.kotlin:*
-          - org.jetbrains.kotlin.jvm
-          - com.google.devtools.ksp
 registries:
   maven-google:
     type: maven-repository


### PR DESCRIPTION
Removed kotlin-ksp patterns from dependabot configuration.