### PR TITLE
🤖 Simplify dependabot.yml for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     open-pull-requests-limit: 10
-    directory: /
+    directories:
+      - /
+      - /.github/actions/*
     schedule:
       interval: daily
   - package-ecosystem: gradle


### PR DESCRIPTION
> For GitHub Actions, use the value `/`. Dependabot will search the `/.github/workflows` directory, as well as the `action.yml/action.yaml` file from the root directory.  
> https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--