### PR TITLE
🩹 Add explicit `testApi` filter for platform api

### DIFF
--- a/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundPlatforms.kt
+++ b/build-logic/src/main/kotlin/fr/smarquis/playground/buildlogic/utils/PlaygroundPlatforms.kt
@@ -51,7 +51,7 @@ internal object PlaygroundPlatforms {
         "lintChecks", "lintDebug", "lintRelease",
     )
 
-    private val testConfigurationRegex = "(androidTest|unitTest|instrumentedTest|jvmTest|androidUnitTest)".toRegex(IGNORE_CASE)
+    private val testConfigurationRegex = "(androidTest|unitTest|instrumentedTest|jvmTest|androidUnitTest|testApi)".toRegex(IGNORE_CASE)
 
     /**
      * Best effort fuzzy matching on known configuration names that we want to opt into platforming.


### PR DESCRIPTION
To fix the following warning message:

```
w: Unsupported API dependency types in test source sets
API dependency types are used in test source sets
Dependencies:
    - Android-Playground:platform:unspecified (source sets: test)

Adding API dependency types to test source sets is not supported and will removed in a future version of Kotlin.
```