### PR TITLE
Revert "Bump github/codeql-action from 4 to 4.37.3 (#698)"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -167,13 +167,13 @@ jobs:
           xml: "**/build/reports/lint-results*.xml"
       - name: 🔍 Analyze app SARIF report
         if: ${{ !cancelled() && hashFiles('app/**/*.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@v4.37.3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: app
           category: app
       - name: 🔍 Analyze build-logic SARIF report
         if: ${{ !cancelled() && hashFiles('build-logic/**/*.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@v4.37.3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: build-logic
           category: build-logic


### PR DESCRIPTION
This reverts commit bd4205f650fa7ceadfb56994963825affc88d106.